### PR TITLE
Easier template handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 ausarbeitung.pdf
 graphics/*.pdf_tex
 graphics/*svg-converted-to.pdf
+ausarbeitung-blx.bib

--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ The template has been built primarily for German documents. English documents, h
 
 Two steps to switch to English typesetting:
 
-1. `ausarbeitung.tex`: Right on top: remove the `%` before `pointlessnumbers` (line 17)
-1. `ausarbeitung.tex`: Exchange commands `\ifdeutsch` and `\ifenglisch`. (Lines 23,23 <-> 27,28).
-1. `preambel/packages_and_options.tex` at `usepackage` of `uni-stuttgart-cs-cover`: disabled `language=german` and enable `language=english`. (Lines 448 and 449)
+1. `ausarbeitung.tex`: Exchange commands `\ifdeutsch` and `\ifenglisch`. (Lines 11,12 <-> 15,16).
 1. Cleanup everything (e.g., `latexmk -c ausarbeitung`). Otherwise pdflatex will complain because of `ngerman`.
 
 Change Appearance of Chapter Headings

--- a/ausarbeitung.tcp
+++ b/ausarbeitung.tcp
@@ -1,0 +1,12 @@
+[FormatInfo]
+Type=TeXnicCenterProjectInformation
+Version=4
+
+[ProjectInfo]
+MainFile=ausarbeitung.tex
+UseBibTeX=1
+UseMakeIndex=0
+ActiveProfile=LaTeX ⇨ PDF
+ProjectLanguage=en
+ProjectDialect=US
+

--- a/ausarbeitung.tex
+++ b/ausarbeitung.tex
@@ -5,7 +5,20 @@
 %Ermöglicht \\ bei der Titelseite (z.B. bei supervisor)
 %Siehe https://github.com/latextemplates/uni-stuttgart-cs-cover/issues/4
 \RequirePackage{kvoptions-patch}
+
+
+%Englisch:
+\let\ifdeutsch\iffalse
+\let\ifenglisch\iftrue
+
+%Deutsch:
+%\let\ifdeutsch\iftrue
+%\let\ifenglisch\iffalse
+
 %
+\ifdeutsch
+	\PassOptionsToClass{numbers=noenddot}{scrbook}
+\fi
 \documentclass[
                fontsize=12pt, %Default: 11pt, bei Linux Libertine zu klein zum Lesen
                paper=a4,
@@ -19,18 +32,9 @@
                headsepline,
                cleardoublepage=empty,
                parskip=half,
-%                pointlessnumbers, %f"ur englische Texte, dann unten \ifdeutsch und \ifenglisch anpassen.
 %               draft    % um zu sehen, wo noch nachgebessert werden muss - wichtig, da Bindungskorrektur mit drin
                final   % ACHTUNG! - in pagestyle.tex noch Seitenstil anpassen
                ]{scrbook}
-
-%Englisch:
-%\let\ifdeutsch\iffalse
-%\let\ifenglisch\iftrue
-
-%Deutsch:
-\let\ifdeutsch\iftrue
-\let\ifenglisch\iffalse
 
 
 \input{preambel/packages_and_options}
@@ -72,6 +76,7 @@
 
 
 \begin{document}
+
 %tex4ht-Konvertierung verschönern
 \iftex4ht
 % tell tex4ht to create picures also for formulas starting with '$'

--- a/ausarbeitung.tex
+++ b/ausarbeitung.tex
@@ -8,12 +8,12 @@
 
 
 %Englisch:
-\let\ifdeutsch\iffalse
-\let\ifenglisch\iftrue
+%\let\ifdeutsch\iffalse
+%\let\ifenglisch\iftrue
 
 %Deutsch:
-%\let\ifdeutsch\iftrue
-%\let\ifenglisch\iffalse
+\let\ifdeutsch\iftrue
+\let\ifenglisch\iffalse
 
 %
 \ifdeutsch

--- a/ausarbeitung.tex
+++ b/ausarbeitung.tex
@@ -61,6 +61,16 @@
 }
 \makeatother
 
+
+%%% acro
+% alle Acronyme die verwendet werden kommen hier her.
+
+\DeclareAcronym{ER}{short = ER , long = error rate}
+\DeclareAcronym{FR}{short = FR , long = Fehlerrate}
+
+%%%
+
+
 \begin{document}
 %tex4ht-Konvertierung verschönern
 \iftex4ht
@@ -124,7 +134,6 @@
 %
 % oder zB
 %\addcontentsline{toc}{section}{Abkürzungsverzeichnis}
-%\section*{Abkürzungsverzeichnis}
 %
 %%%
 
@@ -168,6 +177,12 @@
 \listoffigures
 \let\cleardoublepage\relax
 \listoftables
+
+\ifdeutsch
+\printacronyms[name=Abkürzungsverzeichnis, heading=chapter*]
+\else
+\printacronyms[name=List of Acronyms]
+\fi
 
 %Wird nur bei Verwendung von der lstlisting-Umgebung mit dem "caption"-Parameter benoetigt
 %\lstlistoflistings 

--- a/ausarbeitung.tex
+++ b/ausarbeitung.tex
@@ -186,7 +186,7 @@
 \ifdeutsch
 \printacronyms[name=Abkürzungsverzeichnis, heading=chapter*]
 \else
-\printacronyms[name=List of Acronyms]
+\printacronyms[name=List of Acronyms, heading=chapter*]
 \fi
 
 %Wird nur bei Verwendung von der lstlisting-Umgebung mit dem "caption"-Parameter benoetigt

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,10 +1,17 @@
 %Literaturverzeichnis am besten mit JabRef (http://jabref.sf.net) bearbeiten
 
+%%%
+%
+%Beim Erstellen der Bibtex-Datei wird empfohlen darauf zu achten, dass die DOI aufgeführt wird.
+%
+%%%
+
 @book{WSPA,
 author={Sanjiva Weerawarana and Francisco Curbera and Frank Leymann and Tony Storey and Donald F. Ferguson},
 title={Web Services Platform Architecture : SOAP, WSDL, WS-Policy, WS-Addressing, WS-BPEL, WS-Reliable Messaging, and More},
 year={2005},
 price={$31.49},
 publisher={Prentice Hall PTR},
-isbn={0131488740}
+isbn={0131488740},
+doi = {10.1.1/jpb001}
 }

--- a/content/latex-tipps.tex
+++ b/content/latex-tipps.tex
@@ -17,6 +17,8 @@ Beispiel: \cite{WSPA} oder mit Authorenangabe: \citet{WSPA}.
 
 Wörter am besten mittels \texttt{\textbackslash enquote\{...\}} \enquote{einschließen}, dann werden die richtigen Anführungszeichen verwendet.
 
+Beim Erstellen der Bibtex-Datei wird empfohlen darauf zu achten, dass die DOI aufgeführt wird.
+
 \section{Mathematische Formeln}
 \label{sec:mf}
 Mathematische Formeln kann man $so$ setzen. \texttt{symbols-a4.pdf} (zu finden auf \url{http://www.ctan.org/tex-archive/info/symbols/comprehensive/symbols-a4.pdf}) enthält eine Liste der unter LaTeX direkt verfügbaren Symbole. z.\,B.\ $\mathbb{N}$ für die Menge der natürlichen Zahlen. Für eine vollständige Dokumentation für mathematischen Formelsatz sollte die Dokumentation zu \texttt{amsmath}, \url{ftp://ftp.ams.org/pub/tex/doc/amsmath/} gelesen werden.

--- a/content/latex-tipps.tex
+++ b/content/latex-tipps.tex
@@ -118,20 +118,20 @@ Tabelle~\ref{tab:Ergebnisse} zeigt Ergebnisse und die Tabelle~\ref{tab:Ergebniss
 	\begin{tabular}{l *{8}{d{3.2}}}
 		\toprule
 						
-			  \multirow{2}{*}{\textbf{Bedingungen}} & \multicolumn{2}{c}{\textbf{Parameter 1}} & \multicolumn{2}{c}{\textbf{Parameter 2}} & \multicolumn{2}{c}{\textbf{Parameter 3}} & \multicolumn{2}{c}{\textbf{Parameter 4}} \\
+			   & \multicolumn{2}{c}{\textbf{Parameter 1}} & \multicolumn{2}{c}{\textbf{Parameter 2}} & \multicolumn{2}{c}{\textbf{Parameter 3}} & \multicolumn{2}{c}{\textbf{Parameter 4}} \\
 			\cmidrule(r){2-3}\cmidrule(lr){4-5}\cmidrule(lr){6-7}\cmidrule(l){8-9}
 			
-			& \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}}\\
+			\textbf{Bedingungen} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}}\\
 			\midrule
 			
 			W & 1.1 & 5.55 & 6.66 & .01 &  &  &  & \\
 			X & 22.22 & 0.0 & 77.5 & .1 &  &  &  & \\
 			Y & 333.3 & .1 & 11.11 & .05 &  &  &  & \\
-			Z & 4444.44 & 77.777 & 14.06 & .3 &  &  &  & \\
+			Z & 4444.44 & 77.77 & 14.06 & .3 &  &  &  & \\
 		\bottomrule 
 	\end{tabular}
 	
-	\caption{Beispieltabelle f\"{u}r 4 Bedingungen (W-Z) mit jeweils 4 Parameters mit (M und SD)}
+	\caption{Beispieltabelle f\"{u}r 4 Bedingungen (W-Z) mit jeweils 4 Parameters mit (M und SD). Hinweiß: immer die selbe anzahl an Nachkommastellen angeben.}
 	\label{tab:Werte}
 \end{table}
 
@@ -192,6 +192,16 @@ test2\\
 \hrule height .5pt width\textwidth
 }
 
+
+\section{Abkürzungen}
+
+Beim ersten Durchlaf betrug die \ac{FR} 5. Beim zweiten Durchlauf war die \ac{FR} 3.
+
+Mit \verb+\ac{...}+ können Abkürungen eingebaut werden, beim ersten aufrufen wird die lange Form eingesetzt. Beim wiederholten werwenden von \verb+\ac{...}+ wird automatisch die kurz Form angezeigt. Außerdem wird die Abkürzung automatisch in die Abkürzungsliste eingefügt.
+
+Definiert werden Abkürzungen in der Datei \textit{ausarbeitung.tex} im Abschnitt '\%\%\% acro' mithilfe von \verb+\DeclareAcronym{...}{...}+.
+
+Mehr infos unter: \url{http://mirror.hmc.edu/ctan/macros/latex/contrib/acro/acro_en.pdf}
 
 \section{Verweise}
 Für weit entfernte Abschnitte ist \enquote{varioref} zu empfehlen:

--- a/content/latex-tipps.tex
+++ b/content/latex-tipps.tex
@@ -73,6 +73,19 @@ wichtig. Im Anhang zeigt \vref{fig:AnhangsChor} erneut die komplette Choreograph
   \end{center}
 \end{figure}
 
+
+\begin{figure}
+  \centering
+    \subfloat[]{\includegraphics[width=0.3\textwidth]{choreography.pdf} \label{fig:subfigA}}
+    \subfloat[]{\includegraphics[width=0.3\textwidth]{choreography.pdf} \label{fig:subfigB}}
+		\subfloat[]{\includegraphics[width=0.3\textwidth]{choreography.pdf} \label{fig:subfigC}}
+	\caption{Beispiel um 3 Abbildung nebeneinader zu stellen nur jedes einzeln referenzieren zu können. Abbildung~\ref{fig:subfigB}
+ ist die mittlere Abbildung.}
+\label{fig:subfig_example}
+\end{figure}
+
+
+
 Das SVG in \cref{fig:directSVG} ist direkt eingebunden, während der Text im SVG in \cref{fig:latexSVG} mittels pdflatex gesetzt ist.
 \todo{Falls man die Graphiken sehen möchte, muss inkscape im PATH sein und im Tex-Quelltext \texttt{\textbackslash{}iffalse} und \texttt{\textbackslash{}iftrue} auskommentiert sein.}
 

--- a/content/latex-tipps.tex
+++ b/content/latex-tipps.tex
@@ -51,7 +51,7 @@ Eine ausführliche Anleitung zum Mathematikmodus von LaTeX findet sich in \url{h
 Quellcode im \lstinline|<listing />| ist auch möglich.
 
 \section{Abbildungen}
-Die Abbildungen~\ref{fig:chor1} und~\ref{fig:chor2} sind für das Verständnis dieses Dokuments
+Die \cref{fig:chor1} und \ref{fig:chor2} sind für das Verständnis dieses Dokuments
 wichtig. Im Anhang zeigt \vref{fig:AnhangsChor} erneut die komplette Choreographie.
 
 %Die Parameter in eckigen Klammern sind optionale Parameter - z.B. [htb!]
@@ -84,8 +84,6 @@ wichtig. Im Anhang zeigt \vref{fig:AnhangsChor} erneut die komplette Choreograph
 \label{fig:subfig_example}
 \end{figure}
 
-
-
 Das SVG in \cref{fig:directSVG} ist direkt eingebunden, während der Text im SVG in \cref{fig:latexSVG} mittels pdflatex gesetzt ist.
 \todo{Falls man die Graphiken sehen möchte, muss inkscape im PATH sein und im Tex-Quelltext \texttt{\textbackslash{}iffalse} und \texttt{\textbackslash{}iftrue} auskommentiert sein.}
 
@@ -108,7 +106,7 @@ Das SVG in \cref{fig:directSVG} ist direkt eingebunden, während der Text im SVG
 
 \section{Tabellen}
 
-Tabelle~\ref{tab:Ergebnisse} zeigt Ergebnisse und die Tabelle~\ref{tab:Ergebnisse} zeigt wie numerische Daten in einer Tabelle representiert werden können.
+\cref{tab:Ergebnisse} zeigt Ergebnisse und die \cref{tab:Ergebnisse} zeigt wie numerische Daten in einer Tabelle representiert werden können.
 \begin{table}
   \begin{center}
     \begin{tabular}{ccc}

--- a/content/latex-tipps.tex
+++ b/content/latex-tipps.tex
@@ -80,7 +80,7 @@ wichtig. Im Anhang zeigt \vref{fig:AnhangsChor} erneut die komplette Choreograph
   \centering
     \subfloat[]{\includegraphics[width=0.3\textwidth]{choreography.pdf} \label{fig:subfigA}}
     \subfloat[]{\includegraphics[width=0.3\textwidth]{choreography.pdf} \label{fig:subfigB}}
-		\subfloat[]{\includegraphics[width=0.3\textwidth]{choreography.pdf} \label{fig:subfigC}}
+		\subfloat[Subcaption if needed]{\includegraphics[width=0.3\textwidth]{choreography.pdf} \label{fig:subfigC}}
 	\caption{Beispiel um 3 Abbildung nebeneinader zu stellen nur jedes einzeln referenzieren zu können. Abbildung~\ref{fig:subfigB}
  ist die mittlere Abbildung.}
 \label{fig:subfig_example}

--- a/content/latex-tipps.tex
+++ b/content/latex-tipps.tex
@@ -94,7 +94,8 @@ Das SVG in \cref{fig:directSVG} ist direkt eingebunden, während der Text im SVG
 \fi % <-- Das hier wegnehmen, falls inkscape im Pfad ist
 
 \section{Tabellen}
-Tabelle~\ref{tab:Ergebnisse} zeigt Ergebnisse.
+
+Tabelle~\ref{tab:Ergebnisse} zeigt Ergebnisse und die Tabelle~\ref{tab:Ergebnisse} zeigt wie numerische Daten in einer Tabelle representiert werden können.
 \begin{table}
   \begin{center}
     \begin{tabular}{ccc}
@@ -110,6 +111,28 @@ Tabelle~\ref{tab:Ergebnisse} zeigt Ergebnisse.
     \caption[Beispieltabelle]{Beispieltabelle -- siehe \url{http://www.ctan.org/tex-archive/info/german/tabsatz/}}
     \label{tab:Ergebnisse}
   \end{center}
+\end{table}
+
+\begin{table}
+	\centering
+	\begin{tabular}{l *{8}{d{3.2}}}
+		\toprule
+						
+			  \multirow{2}{*}{\textbf{Bedingungen}} & \multicolumn{2}{c}{\textbf{Parameter 1}} & \multicolumn{2}{c}{\textbf{Parameter 2}} & \multicolumn{2}{c}{\textbf{Parameter 3}} & \multicolumn{2}{c}{\textbf{Parameter 4}} \\
+			\cmidrule(r){2-3}\cmidrule(lr){4-5}\cmidrule(lr){6-7}\cmidrule(l){8-9}
+			
+			& \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}} & \multicolumn{1}{c}{\textbf{M}} & \multicolumn{1}{c}{\textbf{SD}}\\
+			\midrule
+			
+			W & 1.1 & 5.55 & 6.66 & .01 &  &  &  & \\
+			X & 22.22 & 0.0 & 77.5 & .1 &  &  &  & \\
+			Y & 333.3 & .1 & 11.11 & .05 &  &  &  & \\
+			Z & 4444.44 & 77.777 & 14.06 & .3 &  &  &  & \\
+		\bottomrule 
+	\end{tabular}
+	
+	\caption{Beispieltabelle f\"{u}r 4 Bedingungen (W-Z) mit jeweils 4 Parameters mit (M und SD)}
+	\label{tab:Werte}
 \end{table}
 
 \section{Pseudocode}
@@ -168,6 +191,7 @@ test2\\
 \vskip-.9em
 \hrule height .5pt width\textwidth
 }
+
 
 \section{Verweise}
 Für weit entfernte Abschnitte ist \enquote{varioref} zu empfehlen:

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -172,12 +172,29 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 --export-pdf=\getgraphicspath#1.pdf --export-latex}%
 \input{\getgraphicspath#1.pdf_tex}%
 }
+
+
 %%%
+\usepackage{siunitx}
+%%%
+
+%%%
+\usepackage{acro} %nice Acronyms
+%\DeclareAcronym{TCT}{short = TCT , long = task completion time}
+%%%
+
 
 %%%
 % Tabellenerweiterungen
 \usepackage{array} %increases tex's buffer size and enables ``>'' in tablespecs
 \usepackage{longtable}
+\usepackage{dcolumn} %Aligning numbers by decimal points in table columns
+\ifdeutsch
+	\newcolumntype{d}[1]{D{.}{,}{#1}}
+\else
+	\newcolumntype{d}[1]{D{.}{.}{#1}}
+\fi
+
 %
 %%%
 
@@ -185,6 +202,13 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 % Eine Zelle, die sich über mehrere Zeilen erstreckt.
 % Siehe Beispieltabelle in Kapitel 2
 \usepackage{multirow}
+%
+%%%
+
+%%%
+%Fuer Tabellen mit Variablen Spaltenbreiten
+%\usepackage{tabularx}
+%\usepackage{tabulary}
 %
 %%%
 
@@ -296,12 +320,6 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 %%%
 
 
-%%%
-%Fuer Tabellen mit Variablen Spaltenbreiten
-%\usepackage{tabularx}
-%\usepackage{tabulary}
-%
-%%%
 
 
 %%%

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -411,7 +411,8 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 %%%
 %biblatex statt bibtex
 \usepackage[
-  backend       = biber, %minalphanames only works with biber backend
+  backend       = biber, 	%biber dose not work with 64x versions alternative: bibtex8
+														%minalphanames only works with biber backend														
   bibstyle      = alphabetic,
   citestyle     = alphabetic,
   firstinits    = true,
@@ -420,8 +421,13 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
   maxalphanames = 4,
   maxbibnames   = 99,
   maxcitenames  = 3,
+	natbib        = true,
+	doi           = true,
+	eprint        = true,
+	url           = true,
   backref       = true]{biblatex}
 \bibliography{bibliography}
+%\addbibresource[datatype=bibtex]{bibliography.bib}
 
 \DefineBibliographyStrings{ngerman}{
   backrefpage  = {Zitiert auf S\adddot},
@@ -431,10 +437,6 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
   bibliography = {Literaturverzeichnis}
 }
 
-%natbib compatibility
-\newcommand{\citep}[1]{\cite{#1}}
-\newcommand{\citet}[1]{\citeauthor{#1} \cite{#1}}
-%%%
 
 %%%
 % Neue Pakete bitte VOR hyperref einbinden. Insbesondere bei Verwendung des

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -316,6 +316,7 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 % Fuer Abbildungen innerhalb von Abbildungen
 % Ersetzt das Paket subfigure
 %\usepackage{subfig}
+\usepackage[caption=false]{subfig}
 %
 %%%
 

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -520,7 +520,12 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 %%%
 % Deckblattstyle
 %
-% für englische Ausarbeitungen "language=english" benutzen
+\ifdeutsch
+	\PassOptionsToPackage{language=german}{uni-stuttgart-cs-cover}
+\else
+	\PassOptionsToPackage{language=english}{uni-stuttgart-cs-cover}
+\fi
+
 \usepackage[
     title={Förderungswürdigkeit der F\"{o}rderung von Öl},
     author={Lars K.},
@@ -532,9 +537,7 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
     supervisor={Dipl.-Inf.\ Roman Tiker,\\Dipl.-Inf.\ Laura Stern,\\Otto Normalverbraucher,\ M.Sc.},
     startdate={5.\ Juli 2013}, % English: July 5, 2013;    ISO: 2013-07-05
     enddate={5.\ Januar 2014}, % English: January 5, 2014; ISO: 2014-01-05
-    crk={I.7.2},
-    language=german
-    %language=english
+    crk={I.7.2}
     ]{uni-stuttgart-cs-cover}
 %
 %%%

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -316,7 +316,7 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 % Fuer Abbildungen innerhalb von Abbildungen
 % Ersetzt das Paket subfigure
 %\usepackage{subfig}
-\usepackage[caption=false]{subfig}
+\usepackage[caption=false, lofdepth=1, lotdepth]{subfig}
 %
 %%%
 
@@ -481,10 +481,9 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 %%%
 % cleveref für cref statt autoref, da cleveref auch bei Definitionen funktioniert
 \ifdeutsch
-\usepackage[ngerman,capitalise,nameinlink]{cleveref}
-\crefname{figure}{Abbildung}{Abbildungen}
+\usepackage[ngerman,capitalise,nameinlink,noabbrev]{cleveref}
 \else
-\usepackage[capitalise,nameinlink]{cleveref}
+\usepackage[capitalise,nameinlink,noabbrev]{cleveref}
 \fi
 %%%
 

--- a/preambel/packages_and_options.tex
+++ b/preambel/packages_and_options.tex
@@ -312,10 +312,15 @@ inkscape -z -D --file=\getgraphicspath#1.svg %
 %%%
 
 
+
 %%%
 % Fuer Abbildungen innerhalb von Abbildungen
 % Ersetzt das Paket subfigure
-%\usepackage{subfig}
+%
+% Due to bug #24 in the caption package we need to update caption3.sty at the moment manualy to use subfig.
+% Bug #24: http://sourceforge.net/p/latex-caption/tickets/24/
+% corrected caption3.sty: http://sourceforge.net/p/latex-caption/code/HEAD/tree/branches/3.3/tex/caption3.sty
+%
 \usepackage[caption=false, lofdepth=1, lotdepth]{subfig}
 %
 %%%


### PR DESCRIPTION
All my changes wich helps to use the template
- Switching languages with only one comment change
- added usepackage subfig + example
- Including DOI's for better handling of the references
- fix wrong heading for List of Acronyms in the English version
- no use of abbreviations when using \cref{} to use abbreviations here is not common the a thesis
- standard use of \usepackage{acro} for abbreviations + example
-  second table example for nice number formatting
